### PR TITLE
A format Python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@ fied/_version.py
 !/data/dir_structure.md
 *.pyc
 *.pkl
+
 # pixi environments
 .pixi
+
+# Distribution / packaging
 *.egg-info
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Dynamic version
+fied/_version.py
+
 /data/*
 !/data/dir_structure.md
 *.pyc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Foundational Industry Energy Dataset (FIED)
 
+**FIED** is a dataset that compiles and estimates unit-level information for
+industrial energy analysis and modeling.
+
 ## Summary
 
 This is an effort by the National Renewable Energy Laboratory (NREL) and Argonne National Laboratory (ANL) to create an experimental foundational industry dataset for energy and emissions analysis and modeling. The code draws from various publicly-available data, primarily from the U.S. EPA, to compile a data set on unit-level energy use and characterization for U.S. industrial facilities in 2017.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,0 @@
-Foundational Industry Energy Dataset (FIED)
-===========================================
-
-**FIED** is a dataset that compiles and estimates unit-level information for industrial energy analysis and modeling. 

--- a/fied/__init__.py
+++ b/fied/__init__.py
@@ -1,0 +1,3 @@
+"""Foundational Industry Energy Dataset (FIED)"""
+
+from ._version import __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = "fied"
 dynamic = ["version"]
+readme = "README.md"
 authors = [
   {name = "Colin McMillan"},
   {name = "Gui Castelao", email = "gpimenta@nrel.gov"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,16 @@
 [project]
-authors = [{name = "Gui Castelao", email = "guilherme@castelao.net"}]
-dependencies = []
+authors = [
+  {name = "Colin McMillan"},
+  {name = "Gui Castelao", email = "gpimenta@nrel.gov"}
+	]
+maintainers = [
+  {name = "Gui Castelao", email = "gpimenta@nrel.gov"}
+	]
 description = "Add a short description here"
 name = "fied"
 requires-python = ">= 3.9"
 version = "0.0.1"
+dependencies = []
 
 [build-system]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ maintainers = [
 	]
 description = "Add a short description here"
 requires-python = ">= 3.9"
-version = "0.0.1"
 dependencies = [
   "geopandas>=0.12.1",
   "matplotlib>=3.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ dependencies = [
   "tqdm>=4.67.1,<5",
 ]
 
+[project.urls]
+homepage = "https://github.com/NREL/foundational-industry-energy-data"
+documentation = "https://nrel.github.io/foundational-industry-energy-data/"
+repository = "https://github.com/NREL/foundational-industry-energy-data"
+
 [tool.pixi.project]
 channels = ["conda-forge", "anaconda", "main"]
 platforms = ["osx-arm64", "linux-64", "win-64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,18 @@ maintainers = [
   {name = "Gui Castelao", email = "gpimenta@nrel.gov"}
 	]
 requires-python = ">= 3.9"
+classifiers=[
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "geopandas>=0.12.1",
   "matplotlib>=3.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,22 @@ description = "Add a short description here"
 name = "fied"
 requires-python = ">= 3.9"
 version = "0.0.1"
-dependencies = []
+dependencies = [
+  "geopandas>=0.12.1",
+  "matplotlib>=3.6.2",
+  "numpy>=1.23.4",
+  "openpyxl>=3.0.10",
+  "pandas>=1.2.0",
+  "plotly>=5.11.0",
+  "pyarrow>=9.0.0",
+  "pyyaml>=6.0",
+  "pyxlsb>=1.0.10",
+  "requests>=2.28.1",
+  "seaborn>=0.12.1",
+  "scikit-learn>=1.1.3",
+  "pooch>=1.8.2,<2",
+  "tqdm>=4.67.1,<5",
+]
 
 [build-system]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = [
+  "setuptools >= 61",
+  "setuptools_scm[toml] >= 8",
+]
+build-backend = 'setuptools.build_meta'
+
 [project]
 authors = [
   {name = "Colin McMillan"},
@@ -26,10 +33,6 @@ dependencies = [
   "pooch>=1.8.2,<2",
   "tqdm>=4.67.1,<5",
 ]
-
-[build-system]
-build-backend = "hatchling.build"
-requires = ["hatchling"]
 
 [tool.pixi.project]
 channels = ["conda-forge", "anaconda", "main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = "fied"
 dynamic = ["version"]
+description = "The Foundational Industry Energy Dataset (FIED) is a unit-level characterization of energy use in the U.S. industrial sector"
 readme = "README.md"
 authors = [
   {name = "Colin McMillan"},
@@ -16,7 +17,6 @@ authors = [
 maintainers = [
   {name = "Gui Castelao", email = "gpimenta@nrel.gov"}
 	]
-description = "Add a short description here"
 requires-python = ">= 3.9"
 dependencies = [
   "geopandas>=0.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [project]
+name = "fied"
+dynamic = ["version"]
 authors = [
   {name = "Colin McMillan"},
   {name = "Gui Castelao", email = "gpimenta@nrel.gov"}
@@ -14,7 +16,6 @@ maintainers = [
   {name = "Gui Castelao", email = "gpimenta@nrel.gov"}
 	]
 description = "Add a short description here"
-name = "fied"
 requires-python = ">= 3.9"
 version = "0.0.1"
 dependencies = [
@@ -151,3 +152,9 @@ max-doc-length = 72
 convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
+
+[tool.setuptools]
+packages = ["fied"]
+
+[tool.setuptools_scm]
+version_file = "fied/_version.py"


### PR DESCRIPTION
FIED was until structured as a well organized collection of scripts. This PR migrate it into a formal Python package. Some motivations are:
- This is the process to simplify the pipeline and minimize the requirement on defining explicit paths.
- Better structure to build documentation.
- Better structure to run tests to validate the code.
- More metadata describing the package while following largely used standards.
- More robust structure to run in different machines and stronger support for reproducibility.
- Make it easier for others to re-use components developed here. For instance, someone might be interested in building an alternative dataset with some of the components integrated here. With a structure as a package it is easier to re-use.