### PR TITLE
Fetch FRS

### DIFF
--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -17,9 +17,10 @@ from pooch import HTTPDownloader
 def fetch_frs(combined=True):
     """Fetch the Facility Registry Service (FRS) dataset from EPA
 
-    NOTE: It looks like this dataset is updated frequently. The current
-    download is only 20 days old. If the updates are too frequent, it
-    might be impractical to validate the hash.
+    NOTE: This dataset might be updated frequently. The current
+    downloaded files are only 20 days old. If the updates are too
+    frequent, it might be cumbersome to keep the hash up to date (but
+    still important for reproducibility).
 
     Combined file was ~732 MB on Dec 2022, and ~1.2 GB on Feb 2025.
 

--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -52,7 +52,7 @@ def fetch_frs(combined=True):
     fnames = pooch.retrieve(
         url=url,
         known_hash=knwon_hash,
-        path=pooch.os_cache("FIED"),
+        path=pooch.os_cache("FIED") / "FRS",
         downloader=HTTPDownloader(progressbar=True),
         processor=pooch.Unzip(members=members),
     )

--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -14,6 +14,52 @@ import pooch
 from pooch import HTTPDownloader
 
 
+def fetch_frs(combined=True):
+    """Fetch the Facility Registry Service (FRS) datase
+
+    NOTE: It looks like this dataset is updated frequently. The current
+    download is only 20 days old. If the updates are too frequent, it
+    might be impractical to validate the hash.
+
+    Parameters
+    ----------
+    combined : bool, optional
+        If True, download the combined dataset, by default True.
+        Otherwise, download the single dataset.
+    """
+    if combined:
+        url = "https://ordsext.epa.gov/FLA/www3/state_files/national_combined.zip"
+        knwon_hash = "sha256:3575cc51c8fa44daa25382871515e068db42645f2e683a80e1238bf5200502ab"
+        members = [
+            "NATIONAL_ALTERNATIVE_NAME_FILE.CSV",
+            "NATIONAL_CONTACT_FILE.CSV",
+            "NATIONAL_ENVIRONMENTAL_INTEREST_FILE.CSV",
+            "NATIONAL_FACILITY_FILE.CSV",
+            "NATIONAL_MAILING_ADDRESS_FILE.CSV",
+            "NATIONAL_NAICS_FILE.CSV",
+            "NATIONAL_ORGANIZATION_FILE.CSV",
+            "NATIONAL_PROGRAM_FILE.CSV",
+            "NATIONAL_SIC_FILE.CSV",
+            "NATIONAL_SUPP_INTEREST_FILE.CSV",
+        ]
+    else:
+        url = (
+            "https://ordsext.epa.gov/FLA/www3/state_files/national_single.zip"
+        )
+        knwon_hash = "sha256:1c41e349dfcf7f4ac4db2eb99b0814eb89cab980bf4880ad427fdfe289eaa979"
+        members = ["NATIONAL_SINGLE.CSV"]
+
+    fnames = pooch.retrieve(
+        url=url,
+        known_hash=knwon_hash,
+        path=pooch.os_cache("FIED"),
+        downloader=HTTPDownloader(progressbar=True),
+        processor=pooch.Unzip(members=members),
+    )
+
+    return fnames
+
+
 def fetch_nei_2017():
     """Fetch the 2017 National Emissions Inventory (NEI)
 

--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -15,11 +15,13 @@ from pooch import HTTPDownloader
 
 
 def fetch_frs(combined=True):
-    """Fetch the Facility Registry Service (FRS) datase
+    """Fetch the Facility Registry Service (FRS) dataset from EPA
 
     NOTE: It looks like this dataset is updated frequently. The current
     download is only 20 days old. If the updates are too frequent, it
     might be impractical to validate the hash.
+
+    Combined file was ~732 MB on Dec 2022, and ~1.2 GB on Feb 2025.
 
     Parameters
     ----------

--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -63,6 +63,23 @@ def fetch_frs(combined=True):
     return fnames
 
 
+def fetch_zip_codes():
+    """Fetch the ZIP Code dataset from USPS
+
+    This was originally used by frs_extraction's call_all_fips() on
+    demand, i.e. it accessed the remote file every time it was needed,
+    thus creating a permanent dependency on that service.
+    """
+    fname = pooch.retrieve(
+        url="https://postalpro.usps.com/mnt/glusterfs/2022-12/ZIP_Locale_Detail.xls",
+        known_hash="sha256:fd0689f6801a2d5291354a9d6c25af3656b863c2462b445ba4d4595b024cd5a9",
+        path=pooch.os_cache("FIED"),
+        downloader=HTTPDownloader(progressbar=True),
+    )
+
+    return pd.read_excel(fname)
+
+
 def fetch_nei_2017():
     """Fetch the 2017 National Emissions Inventory (NEI)
 

--- a/fied/frs/frs_extraction.py
+++ b/fied/frs/frs_extraction.py
@@ -102,9 +102,6 @@ class FRS:
         state_abbr_url = \
             'https://www2.census.gov/geo/docs/reference/state.txts'
 
-        zip_code_url = \
-            'https://postalpro.usps.com/mnt/glusterfs/2022-12/ZIP_Locale_Detail.xls'
-
         try:
             r = requests.get(fips_url, params=fips_params)
 
@@ -129,18 +126,13 @@ class FRS:
             state_abbr.columns = [c.lower() for c in state_abbr.columns]
             state_abbr.rename(columns={'state': 'state_abbr'}, inplace=True)
 
-        try:
-            zip_codes = pd.read_excel(zip_code_url)
-
-        except urllib.error.HTTPError as e:
-            logging.error(f'Error with zip code xls:{e}')
-
-        else:
-            zip_codes.columns = [
-                x.lower().replace(' ', '_') for x in zip_codes.columns
-                ]
-            zip_codes.replace(coumns={'physical_state': 'state_abbr'},
-                              inplace=true)
+        zip_codes = datasets.fetch_zip_codes()
+        zip_codes.columns = [
+                x.lower().replace(" ", "_") for x in zip_codes.columns
+            ]
+        zip_codes.replace(
+                coumns={"physical_state": "state_abbr"}, inplace=true
+            )
 
         all_fips_df = pd.merge(
             all_fips_df, state_abbr, on='state_abbr', how='left'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,9 @@ dependencies = [
   "requests>=2.28.1",
   "seaborn>=0.12.1",
   "scikit-learn>=1.1.3",
-  "pooch>=1.8.2,<2",
-  "tqdm>=4.67.1,<5",
+  "pooch>=1.8.2",
+  "tqdm>=4.67.1",
+  "xlrd>=2.0.1",
 ]
 
 [project.urls]
@@ -78,6 +79,7 @@ scikit-learn = "==1.1.3"
 pooch = ">=1.8.2,<2"
 tqdm = ">=4.67.1,<5"
 cryptography = "==36.0.2"
+xlrd = ">=2.0.1,<3"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }


### PR DESCRIPTION
Simplifying the package by relying on `pooch` to manage download of raw data while securing consistency by tracking a checksum of individual files.

This is a transition PR. I'm not implementing a final ideal solution yet. The goal here is:
- To minimize changes in the original code. First robustness and leave optimization and performance for later.
- This component currently downloads over 1.2GB and at this point I want to minimize downloads.
- Don't rely on the data providers on every single time we run the data processing.