### PR TITLE
Loading state FIPS through module datasets

### DIFF
--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -345,3 +345,15 @@ def fetch_shapefile_NHDP():
     )
 
     return gpd.read_file(fname)
+
+
+def fetch_state_FIPS():
+    """Fetch the state FIPS codes"""
+    fname = pooch.retrieve(
+        url="https://www2.census.gov/geo/docs/reference/state.txt",
+        known_hash="sha256:bea4e03f71a1fa0045ae732aabad11fa541e5932b071c2369bb0d325e8cba5a0",
+        path=pooch.os_cache("FIED"),
+        downloader=HTTPDownloader(progressbar=True),
+    )
+
+    return pd.read_csv(fname, sep='|', dtype={'STATE': str, 'STUSAB': str})

--- a/fied/geocoder/geopandas_tools.py
+++ b/fied/geocoder/geopandas_tools.py
@@ -8,6 +8,7 @@ from fied.datasets import (
     fetch_shapefile_congressional_district,
     fetch_shapefile_county,
     fetch_shapefile_NHDP,
+    fetch_state_FIPS,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -16,15 +17,7 @@ logging.basicConfig(level=logging.INFO)
 class FiedGIS:
     
     def __init__(self):
-
-        self._statefips = pd.read_csv(
-            'https://www2.census.gov/geo/docs/reference/state.txt',
-            sep='|', dtype={'STATE': str, 'STUSAB': str}
-            )
-        
-        self._statefips = dict(
-            self._statefips[['STUSAB', 'STATE']].values
-            )
+        self._statefips = dict(fetch_state_FIPS()[['STUSAB', 'STATE']].values)
 
     @staticmethod
     def get_shapefile(year=None, state_fips=None, ftype=None):


### PR DESCRIPTION
Reduce the dependency on census website. Download it on the first time and keep it in cache.