### PR TITLE
More uses for state FIPS

### DIFF
--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -356,7 +356,7 @@ def fetch_state_FIPS():
         downloader=HTTPDownloader(progressbar=True),
     )
 
-    return pd.read_csv(fname, sep="|", dtype={"STATE": str, "STUSAB": str})
+    return fname
 
 
 def fetch_QPC(year):

--- a/fied/frs/frs_extraction.py
+++ b/fied/frs/frs_extraction.py
@@ -97,9 +97,6 @@ class FRS:
         fips_url = 'https://api.census.gov/data/2010/dec/sf1?'
         fips_params = {'get': 'NAME', 'for': 'county:*'}
 
-        state_abbr_url = \
-            'https://www2.census.gov/geo/docs/reference/state.txts'
-
         try:
             r = requests.get(fips_url, params=fips_params)
 
@@ -113,9 +110,7 @@ class FRS:
             all_fips_df.loc[:, 'state_abbr'] = all_fips_df.state.astype('int')
 
         try:
-            state_abbr = pd.read_csv(
-                state_abbr_url, sep='|'
-                )
+            state_abbr = pd.read_csv(datasets.fetch_state_FIPS(), sep='|')
 
         except urllib.error.HTTPError as e:
             logging.error(f'Error with fips csv: {e}')

--- a/fied/geocoder/geo_tools.py
+++ b/fied/geocoder/geo_tools.py
@@ -6,7 +6,7 @@ import os
 import concurrent.futures
 import logging
 
-from fied.datasets import fetch_state_FIPS()
+from fied.datasets import fetch_state_FIPS
 
 logging.basicConfig(level=logging.INFO)
 

--- a/fied/geocoder/geo_tools.py
+++ b/fied/geocoder/geo_tools.py
@@ -6,6 +6,8 @@ import os
 import concurrent.futures
 import logging
 
+from fied.datasets import fetch_state_FIPS()
+
 logging.basicConfig(level=logging.INFO)
 
 
@@ -51,7 +53,7 @@ def fix_county_fips(df):
 
     # Assume that the countyFIPS with len <4 are missing the state FIPS.
     state_fips = pd.read_csv(
-        'https://www2.census.gov/geo/docs/reference/state.txt',
+        fetch_state_FIPS(),
         usecols=[0, 1], names=['statefips', 'stateCode'], sep='|',
         header=0, dtype=str, index_col=['stateCode']
         )

--- a/fied/geocoder/geopandas_tools.py
+++ b/fied/geocoder/geopandas_tools.py
@@ -17,7 +17,8 @@ logging.basicConfig(level=logging.INFO)
 class FiedGIS:
     
     def __init__(self):
-        self._statefips = dict(fetch_state_FIPS()[['STUSAB', 'STATE']].values)
+        state_fips = pd.read_csv(fetch_state_FIPS(), sep="|", dtype={"STATE": str, "STUSAB": str})
+        self._statefips = dict(state_fips[['STUSAB', 'STATE']].values)
 
     @staticmethod
     def get_shapefile(year=None, state_fips=None, ftype=None):


### PR DESCRIPTION
Accessing the state FIPS is required in more places but expected with different formats, so for now let's use the cache just for the raw file.