### PR TITLE
Command line interface

### DIFF
--- a/fied/cli.py
+++ b/fied/cli.py
@@ -1,0 +1,18 @@
+"""FIED's command line interface."""
+
+import click
+
+import fied.frs.frs_extraction
+import fied.fied_compilation
+
+
+@click.command()
+def main():
+    """FIED's command line interface."""
+    fied.frs.frs_extraction.doit()
+
+    fied.fied_compilation.doit()
+
+
+if __name__ == "__main__":
+    main()

--- a/fied/fied_compilation.py
+++ b/fied/fied_compilation.py
@@ -7,16 +7,17 @@ import sys
 import pdb
 import pandas as pd
 import numpy as np
-from tools.naics_matcher import naics_matcher
-from tools.misc_tools import FRS_API
-from tools.misc_tools import Tools
-from scc.scc_unit_id import SCC_ID
-from ghgrp.ghgrp_fac_unit import GHGRP_unit_char
-from nei.nei_EF_calculations import NEI
-from frs.frs_extraction import FRS
-from qpc.census_qpc import QPC
-from geocoder.geopandas_tools import FiedGIS
-import geocoder.geo_tools
+
+from fied.tools.naics_matcher import naics_matcher
+from fied.tools.misc_tools import FRS_API
+from fied.tools.misc_tools import Tools
+from fied.scc.scc_unit_id import SCC_ID
+from fied.ghgrp.ghgrp_fac_unit import GHGRP_unit_char
+from fied.nei.nei_EF_calculations import NEI
+from fied.frs.frs_extraction import FRS
+from fied.qpc.census_qpc import QPC
+from fied.geocoder.geopandas_tools import FiedGIS
+import fied.geocoder.geo_tools
 
 
 logging.basicConfig(level=logging.INFO)
@@ -1202,7 +1203,7 @@ def assemble_final_df(final_energy_data, frs_data, qpc_data, year):
 
     final_data = merge_qpc_data(final_data, qpc_data)
 
-    final_data = geocoder.geo_tools.fix_county_fips(final_data)
+    final_data = fied.geocoder.geo_tools.fix_county_fips(final_data)
 
     # This doesn't result in any additional units.
     # missing_units = frs_api.find_unit_data_parallelized(final_data)

--- a/fied/fied_compilation.py
+++ b/fied/fied_compilation.py
@@ -22,6 +22,7 @@ import fied.geocoder.geo_tools
 
 logging.basicConfig(level=logging.INFO)
 
+unit_regex = Tools().unit_regex
 
 def assign_data_quality(df, dqi):
     """
@@ -1266,7 +1267,7 @@ def save_final_data(final_data, year, fpath=None, fformat='csv', comp='gzip'):
     return
 
 
-if __name__ == '__main__':
+def doit():
     year = 2017
 
     SCC_ID().main()
@@ -1324,3 +1325,6 @@ if __name__ == '__main__':
         )
 
     save_final_data(final_data, year)
+
+if __name__ == '__main__':
+    doit()

--- a/fied/frs/frs_extraction.py
+++ b/fied/frs/frs_extraction.py
@@ -593,6 +593,7 @@ if __name__ == '__main__':
 
     frs_methods = FRS()
 
+    os.makedirs(Path(Path(__file__).parents[1], 'data/FRS'), exist_ok=True)
     frs_data_df = frs_methods.import_format_frs(combined=combined)
     frs_data_df.to_csv(Path(Path(__file__).parents[1], 'data/FRS/frs_data_formatted.csv'))
 

--- a/fied/frs/frs_extraction.py
+++ b/fied/frs/frs_extraction.py
@@ -586,8 +586,7 @@ class FRS:
 
         return eis
 
-
-if __name__ == '__main__':
+def doit():
     # t_start = time.perf_counter()
     combined = True
 
@@ -599,3 +598,6 @@ if __name__ == '__main__':
 
     # t_stop = time.perf_counter()
     # logging.info(f'Program time: {t_stop - t_start:0.2f} seconds')
+
+if __name__ == '__main__':
+    doit()

--- a/fied/ghgrp/ghgrp_fac_unit.py
+++ b/fied/ghgrp/ghgrp_fac_unit.py
@@ -6,7 +6,7 @@ import json
 from pyxlsb import open_workbook
 import logging
 
-import datasets
+from fied import datasets
 
 class GHGRP_unit_char():
 

--- a/fied/ghgrp/ghgrp_fac_unit.py
+++ b/fied/ghgrp/ghgrp_fac_unit.py
@@ -1,4 +1,6 @@
 
+from pathlib import Path
+
 import pandas as pd
 import os
 import yaml
@@ -14,7 +16,7 @@ class GHGRP_unit_char():
 
         logging.basicConfig(level=logging.INFO)
 
-        self._data_dir = os.path.abspath('./data/GHGRP/')
+        self._data_dir = os.path.abspath(Path(__file__).parents[1] / 'data' / 'GHGRP/')
 
         self._ghgrp_energy_file = ghgrp_energy_file
 
@@ -35,7 +37,7 @@ class GHGRP_unit_char():
             generic fuel types that have been applied to NEI data.
         """
 
-        with open('./tools/type_standardization.yml', 'r') as file:
+        with open(Path(__file__).parents[1] / 'tools' / 'type_standardization.yml', 'r') as file:
             docs = yaml.safe_load_all(file)
 
             for i, d in enumerate(docs):

--- a/fied/nei/nei_EF_calculations.py
+++ b/fied/nei/nei_EF_calculations.py
@@ -11,9 +11,9 @@ from io import BytesIO
 from pathlib import Path
 toolspath = str(Path(__file__).parents[1]/"tools")
 sys.path.append(toolspath)
-from misc_tools import Tools
+from fied.tools.misc_tools import Tools
 
-from datasets import fetch_nei_2017, fetch_nei_2020, fetch_webfirefactors
+from fied.datasets import fetch_nei_2017, fetch_nei_2020, fetch_webfirefactors
 
 
 logging.basicConfig(level=logging.INFO)

--- a/fied/qpc/census_qpc.py
+++ b/fied/qpc/census_qpc.py
@@ -4,7 +4,7 @@ import os
 import urllib
 import sys
 sys.path.append(os.path.abspath(""))
-import tools.naics_matcher
+from fied.tools.naics_matcher import naics_matcher
 
 from fied.datasets import fetch_QPC
 
@@ -222,7 +222,7 @@ class QPC:
             values=['weeklyOpHoursLow', 'weeklyOpHours', 'weeklyOpHoursHigh']
             )
 
-        naics_6d = tools.naics_matcher.naics_matcher(
+        naics_6d = naics_matcher(
             qpc_data.reset_index().NAICS
             )
 

--- a/fied/scc/scc_unit_id.py
+++ b/fied/scc/scc_unit_id.py
@@ -5,7 +5,7 @@ import re
 import logging
 import requests
 
-import datasets
+from fied import datasets
 
 
 class SCC_ID:

--- a/fied/scc/scc_unit_id.py
+++ b/fied/scc/scc_unit_id.py
@@ -1,4 +1,6 @@
 
+import os
+
 import pandas as pd
 import numpy as np
 import re
@@ -630,6 +632,7 @@ class SCC_ID:
     def main(self):
         id_scc = SCC_ID()
         id_scc_df = id_scc.build_id()
+        os.makedirs('./scc', exist_ok=True)
         id_scc_df.to_csv('./scc/iden_scc.csv')
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -4993,8 +4993,8 @@ packages:
   timestamp: 1717757963922
 - pypi: .
   name: fied
-  version: 0.0.3.dev0+gcbd322b.d20250324
-  sha256: 7ea3e44641d147cb16adaeed0a43036afe2ce223695a717d2d50a67af49d5148
+  version: 0.0.3.dev4+gb972791.d20250423
+  sha256: ba878555edbe027f2dcd7cc745a691704d796a3d6da4164814f1a7022d108de0
   requires_dist:
   - geopandas>=0.12.1
   - matplotlib>=3.6.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ tqdm = ">=4.67.1,<5"
 cryptography = "==36.0.2"
 xlrd = ">=2.0.1,<3"
 stream-unzip = ">=0.0.95,<0.0.100"
+click = ">=8.1.8,<9"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ homepage = "https://github.com/NREL/foundational-industry-energy-data"
 documentation = "https://nrel.github.io/foundational-industry-energy-data/"
 repository = "https://github.com/NREL/foundational-industry-energy-data"
 
+[project.scripts]
+fied = "fied.cli:main"
+
 [tool.pixi.project]
 channels = ["conda-forge", "anaconda", "main"]
 platforms = ["osx-arm64", "linux-64", "win-64"]


### PR DESCRIPTION
An MVP of CLI. Here we basically address paths, to data and to modules. Although it was implemented as a package, I missed a few places to `import fied`.

Until we can merge #19, I want to minimize changes in the original code, so this is not the final implementation.

One serious problem to deal with are the intermediate products generated. It currently expects a directory `data` where it will place the intermediate products.

@calmc , with this PR, once you start a `pixi shell`, it will make a new command available to you named `fied`. You can test it running `fied --help`, and run the full analysis by running sole `fied`. Once #19 is merged, I'll return to this and add more controls here, such as choosing between '2017' or '2020' edition.