### PR TITLE
Limit WebFires data to simple factors only

### DIFF
--- a/fied/nei/nei_EF_calculations.py
+++ b/fied/nei/nei_EF_calculations.py
@@ -895,10 +895,10 @@ class NEI ():
         """
         idx = (webfr["FORMULA"] == 'FACTOR') | (webfr["FORMULA"].isna())
 
+        # Inform and filter if there are anything other than simple factors
         if (~idx).any():
             p = 1e2 * idx.astype('i').sum() / idx.size
             self.logger.warning(
-                # Add fraction of records to be ignored
                 f"Limiting to {p:.1f}% of WebFires emissions "
                 "(only simple factors)."
                 )

--- a/fied/nei/nei_EF_calculations.py
+++ b/fied/nei/nei_EF_calculations.py
@@ -886,8 +886,24 @@ class NEI ():
         Returns
         -------
         nei_emiss : pandas.DataFrame
-        """
 
+        Notes
+        -----
+        1134 records (7.1%) were different after the bugfix.
+        """
+        idx = (webfr["FORMULA"] == 'FACTOR') | (webfr["FORMULA"].isna())
+
+        if (~idx).any():
+            p = 1e2 * idx.astype('i').sum() / idx.size
+            self.logger.warning(
+                # Add fraction of records to be ignored
+                f"Limiting to {p:.1f}% of WebFires emissions "
+                "(only simple factors)."
+                )
+            webfr = webfr[idx].copy(deep=True)
+        else:
+            webfr = webfr.copy(deep=True)
+        webfr["FACTOR"] = webfr["FACTOR"].astype(float)
         # remove duplicate EFs for the same pollutant and SCC; keep max EF
         webfr = webfr.sort_values('FACTOR').drop_duplicates(
             subset=['SCC', 'NEI_POLLUTANT_CODE'], keep='last'

--- a/fied/nei/nei_EF_calculations.py
+++ b/fied/nei/nei_EF_calculations.py
@@ -889,6 +889,8 @@ class NEI ():
 
         Notes
         -----
+        Ignoring ~ 5% of WebFires emissions data, because those are not simple
+        factors such as a range.
         1134 records (7.1%) were different after the bugfix.
         """
         idx = (webfr["FORMULA"] == 'FACTOR') | (webfr["FORMULA"].isna())


### PR DESCRIPTION
There are other types of formula beyond simple factors, such as range, formula, etc. Those forced the factor column to be read as string to accomodate all the types. Hence, simple ordering doesn't lead to the maximum observed factor, resulting in errors.

For instance, '5e-10' is after '1000' when compared as strings.