### PR TITLE
Include GHGRP data in the package

### DIFF
--- a/fied/ghgrp/calc_GHGRP_energy.py
+++ b/fied/ghgrp/calc_GHGRP_energy.py
@@ -8,6 +8,7 @@ Created on Wed Mar  6 21:12:25 2019
 import os
 import logging
 
+from importlib_resources import files
 import pandas as pd
 import numpy as np
 import get_GHGRP_data
@@ -55,12 +56,12 @@ class GHGRP(FiedGIS, TierEnergy):
     # List of facilities for correction of combustion emissions from Wood
     # and Wood Residuals for using Subpart C Tier 4 calculation methodology.
     wood_facID = pd.read_csv(
-        os.path.abspath(os.path.join(file_dir, 'WoodRes_correction_facilities.csv')),
+        files("fied.data.GHGRP").joinpath("WoodRes_correction_facilities.csv")
         index_col=['FACILITY_ID']
         )
 
     std_efs = pd.read_csv(
-        os.path.abspath(os.path.join(file_dir, 'EPA_FuelEFs.csv')),
+        files("fied.data.GHGRP").joinpath("EPA_FuelEFs.csv")
         index_col=['Fuel_Type']
         )
 
@@ -69,7 +70,7 @@ class GHGRP(FiedGIS, TierEnergy):
     std_efs = std_efs[~std_efs.index.duplicated()]
 
     MECS_regions = pd.read_csv(
-        os.path.abspath(os.path.join(file_dir, 'US_FIPS_Codes.csv')),
+        files("fied.data.GHGRP").joinpath("US_FIPS_Codes.csv")
         index_col=['COUNTY_FIPS']
         )
 

--- a/fied/ghgrp/calc_GHGRP_energy.py
+++ b/fied/ghgrp/calc_GHGRP_energy.py
@@ -56,12 +56,12 @@ class GHGRP(FiedGIS, TierEnergy):
     # List of facilities for correction of combustion emissions from Wood
     # and Wood Residuals for using Subpart C Tier 4 calculation methodology.
     wood_facID = pd.read_csv(
-        files("fied.data.GHGRP").joinpath("WoodRes_correction_facilities.csv")
+        files("fied.data.GHGRP").joinpath("WoodRes_correction_facilities.csv"),
         index_col=['FACILITY_ID']
         )
 
     std_efs = pd.read_csv(
-        files("fied.data.GHGRP").joinpath("EPA_FuelEFs.csv")
+        files("fied.data.GHGRP").joinpath("EPA_FuelEFs.csv"),
         index_col=['Fuel_Type']
         )
 
@@ -70,7 +70,7 @@ class GHGRP(FiedGIS, TierEnergy):
     std_efs = std_efs[~std_efs.index.duplicated()]
 
     MECS_regions = pd.read_csv(
-        files("fied.data.GHGRP").joinpath("US_FIPS_Codes.csv")
+        files("fied.data.GHGRP").joinpath("US_FIPS_Codes.csv"),
         index_col=['COUNTY_FIPS']
         )
 

--- a/fied/ghgrp/heat_rate_uncertainty.py
+++ b/fied/ghgrp/heat_rate_uncertainty.py
@@ -5,6 +5,7 @@ Created on Wed Dec  5 21:50:55 2018
 @author: cmcmilla
 """
 
+from importlib_resources import files
 import pandas as pd
 import os
 import numpy as np
@@ -62,7 +63,7 @@ class FuelUncertainty:
                                    'C_T3EQC4C8MONTHLYINPUTS',
                                    'C_T3EQC5C8MONTHLYINPUTS']}
 
-        self.ef_file_path = os.path.abspath('./data/GHGRP/EPA_FuelEFs.csv')
+        self.ef_file_path = files("fied.data.GHGRP").joinpath("EPA_FuelEFs.csv")
 
         if std_efs is None:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,8 @@ cryptography = "==36.0.2"
 xlrd = ">=2.0.1,<3"
 stream-unzip = ">=0.0.95,<0.0.100"
 click = ">=8.1.8,<9"
-# Remove importlib_resources dependency when Python 3.10 is the minimum supported version
+# Remove importlib_resources dependency when Python 3.10 is the minimum
+# supported version, and use instead: from importlib.resources import files
 importlib_resources = ">=6.5.2,<7"
 
 [tool.pixi.environments]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ cryptography = "==36.0.2"
 xlrd = ">=2.0.1,<3"
 stream-unzip = ">=0.0.95,<0.0.100"
 click = ">=8.1.8,<9"
+# Remove importlib_resources dependency when Python 3.10 is the minimum supported version
+importlib_resources = ">=6.5.2,<7"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,15 @@ convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 
 [tool.setuptools]
+include-package-data = true
 packages = ["fied"]
+
+[tool.setuptools.package-data]
+"fied.data.GHGRP" = [
+  "EPA_FuelEFs.csv",
+  "US_FIPS_Codes.csv",
+  "WoodRes_correction_facilities.csv",
+  ]
 
 [tool.setuptools_scm]
 version_file = "fied/_version.py"


### PR DESCRIPTION
Instead of relying in a correct local path to those data files, include the data in the package and load those files as components of the package.