### PR TITLE
Updating SCC level one `SCCDownload.csv`

### DIFF
--- a/fied/datasets.py
+++ b/fied/datasets.py
@@ -256,7 +256,7 @@ def fetch_scc():
     """
     fname = pooch.retrieve(
         url="https://sor-scc-api.epa.gov/sccwebservices/v1/SCC?format=CSV&sortFacet=scc+level+one&filename=SCCDownload.csv",
-        known_hash="sha256:607d8575ee23d7b054143ac30c49e5f96f91303c48bdf26c40d53094716fb178",
+        known_hash="sha256:1f723ea9b7b4c54418a27f297669df37da24ec9aa34a92c3a835b4f7550aa736",
         path=pooch.os_cache("FIED"),
         downloader=HTTPDownloader(progressbar=True),
     )


### PR DESCRIPTION
One single line in the dataset was updated, thus a different hash:

< "2270002051","Dec 19, 2018 3:16:02 PM","No","","Nonroad","","No","Retired in favor of aggregation as detail is no longer needed.","2016","3/14/2012","2270002022","","","Mobile Sources","Off-highway Vehicle Diesel","Construction and Mining Equipment","Off-highway Trucks","Mobile - Non-Road Equipment - Diesel","","Retired","12","Off-Highway","02","Non-Road Diesel","02","Construction","", ---
> "2270002051","Jun 13, 2025 11:14:24 AM","No","","Point","","No","Unretired and assigned to the Point data category because MOVES Nonroad does not inventory this equipment, and States have emissions for this equipment at point source mines.","","06/13/2025","","","","Mobile Sources","Off-highway Vehicle Diesel","Construction and Mining Equipment","Off-highway Trucks","Mobile - Non-Road Equipment - Diesel","","Active","12","Off-Highway","02","Non-Road Diesel","02","Construction","",