### PR TITLE
Allow publish_pdf on workflow_dispatch for version tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,7 +122,11 @@ jobs:
   publish_pdf:
     name: Publish PDF to release
     needs: build_pdf
-    if: ${{ github.event_name == 'release' }}
+    if: >-
+      ${{ github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      !contains(github.ref_name, '-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Mirror the publish_docs condition so PDFs are attached to the release when the workflow is manually dispatched on a refs/tags/v* tag, not only on native release events.